### PR TITLE
Metadata: Add 3.22 shell

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.16", "3.18", "3.20"],
+    "shell-version": ["3.16", "3.18", "3.20", "3.22"],
     "uuid": "EasyScreenCast@iacopodeenosee.gmail.com",
     "url": "http://iacopodeenosee.wordpress.com/projects/easyscreencast/",
     "name": "EasyScreenCast",


### PR DESCRIPTION
The plugin seems to work with Gnome Shell 3.22.

Changes to be committed:
	modified:   metadata.json