### PR TITLE
Fix crash when no webcam is selected and opening prefs

### DIFF
--- a/utilwebcam.js
+++ b/utilwebcam.js
@@ -16,6 +16,10 @@ const Lang = imports.lang;
 const GLib = imports.gi.GLib;
 const Gst = imports.gi.Gst;
 
+const Gettext = imports.gettext.domain(
+    'EasyScreenCast@iacopodeenosee.gmail.com');
+const _ = Gettext.gettext;
+
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Lib = Me.imports.convenience;


### PR DESCRIPTION
Utilwebcam contains one translatable string which is used
when no webcam is specified. This currently causes a crash
of the preferences, because gettext is not imported in the
file.
This commit adds the gettext imports to utilwebcam.