### PR TITLE
Make extension work with Wayland

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -56,7 +56,7 @@ const EasyScreenCast_Indicator = new Lang.Class({
         this.parent(null, 'EasyScreenCast-indicator');
 
         this.CtrlAudio = new UtilAudio.MixerAudio();
-        this.CtrlWebcam = new UtilWebcam.HelperWebcam();
+        this.CtrlWebcam  = null;
         this.CtrlNotify = new UtilNotify.NotifyManager();
         this.CtrlExe = new UtilExeCmd.ExecuteStuff(this);
 
@@ -172,7 +172,8 @@ const EasyScreenCast_Indicator = new Lang.Class({
         this.timeLabel.set_text(newValue.toString());
     },
 
-     /* Left clicking on the icon toggles the recording
+     /**
+      * Left clicking on the icon toggles the recording
       * options menu. Any other mouse button will start
       * the recording.
       * Some submenus are refreshed to account for new
@@ -184,7 +185,7 @@ const EasyScreenCast_Indicator = new Lang.Class({
         if (button === 1) {
             Lib.TalkativeLog('-*-left click indicator');
 
-            this._addSubMenuAudioRec();
+            this._setupExtensionMenu();
         } else {
             Lib.TalkativeLog('-*-right click indicator');
 
@@ -195,6 +196,46 @@ const EasyScreenCast_Indicator = new Lang.Class({
                 'b', Settings.SHOW_NOTIFY_ALERT_SETTING_KEY);
             this._doRecording();
         }
+    },
+
+    /**
+     * Sets up the menu when the user opens it.
+     */
+    _setupExtensionMenu: function () {
+        this._addSubMenuAudioRec();
+        this._setUpWebCamOptions();
+    },
+
+    /**
+     * Sets up all the options for web-cams. Should only run the
+     * first time the icon is clicked an the CtrlWebcam is still
+     * null.
+     */
+    _setUpWebCamOptions: function () {
+        if (this.CtrlWebcam === null) {
+            this.CtrlWebcam = new UtilWebcam.HelperWebcam();
+
+            //add sub menu webcam recording
+            this._populateSubMenuWebcam();
+
+            //start monitoring inputvideo
+            this.CtrlWebcam.startMonitor();
+        }
+    },
+
+    /**
+     * Adds individual webcam items to the webcam menu.
+     */
+    _populateSubMenuWebcam: function () {
+        let arrMI = this._createMIWebCam();
+
+        for (let element in arrMI) {
+            this.smWebCam.menu.addMenuItem(arrMI[element]);
+        }
+
+        this.smWebCam.label.text = this.WebCamDevice[
+            Settings.getOption('i', Settings.DEVICE_WEBCAM_SETTING_KEY)
+        ];
     },
 
     _addMIRecording: function() {
@@ -240,14 +281,6 @@ const EasyScreenCast_Indicator = new Lang.Class({
     _addSubMenuWebCam: function() {
         this.smWebCam = new PopupMenu.PopupSubMenuMenuItem('', true);
         this.smWebCam.icon.icon_name = 'camera-web-symbolic';
-        var arrMI = this._createMIWebCam();
-        for (var ele in arrMI) {
-            this.smWebCam.menu.addMenuItem(arrMI[ele]);
-        }
-
-        this.smWebCam.label.text =
-            this.WebCamDevice[Settings.getOption(
-                'i', Settings.DEVICE_WEBCAM_SETTING_KEY)];
 
         this.menu.addMenuItem(this.smWebCam);
     },
@@ -461,8 +494,6 @@ const EasyScreenCast_Indicator = new Lang.Class({
     _enable: function() {
         //enable key binding
         this._enableKeybindings();
-        //start monitoring inputvideo
-        this.CtrlWebcam.startMonitor();
         //add indicator
         this.actor.add_actor(this.indicatorBox);
     },
@@ -470,8 +501,12 @@ const EasyScreenCast_Indicator = new Lang.Class({
     _disable: function() {
         //remove key binding
         this._removeKeybindings();
-        //stop monitoring inputvideo
-        Indicator.CtrlWebcam.stopMonitor();
+
+        if (Indicator.CtrlWebcam !== null) {
+            //stop monitoring inputvideo
+            Indicator.CtrlWebcam.stopMonitor();
+        }
+
         //remove indicator
         this.actor.remove_actor(this.indicatorBox);
     },

--- a/extension.js
+++ b/extension.js
@@ -55,6 +55,9 @@ const EasyScreenCast_Indicator = new Lang.Class({
     _init: function() {
         this.parent(null, 'EasyScreenCast-indicator');
 
+        // TODO: Workaround for https://bugzilla.gnome.org/show_bug.cgi?id=776041
+        Settings.setOption(Settings.DEVICE_WEBCAM_SETTING_KEY, -1);
+
         this.CtrlAudio = new UtilAudio.MixerAudio();
         this.CtrlWebcam  = null;
         this.CtrlNotify = new UtilNotify.NotifyManager();
@@ -638,6 +641,9 @@ const EasyScreenCast_Indicator = new Lang.Class({
 
         this.CtrlExe.Spawn(
             'gnome-shell-extension-prefs  EasyScreenCast@iacopodeenosee.gmail.com');
+        this.CtrlWebcam = new UtilWebcam.HelperWebcam();
+
+        Main.Util.trySpawnCommandLine('gnome-shell-extension-prefs  EasyScreenCast@iacopodeenosee.gmail.com');
     },
 
     _onDelayTimeChanged: function() {

--- a/prefs.js
+++ b/prefs.js
@@ -98,9 +98,6 @@ const EasyScreenCastSettingsWidget = new GObject.Class({
             this._updateRowShortcut(
                 Settings.getOption('as', Settings.SHORTCUT_KEY_SETTING_KEY)[0]);
 
-            //update webcam widget state
-            this._updateStateWebcamOptions();
-
             //connect keywebcam signal
             Settings.settings.connect('changed::' + Settings.DEVICE_WEBCAM_SETTING_KEY,
                 () => {
@@ -643,16 +640,16 @@ const EasyScreenCastSettingsWidget = new GObject.Class({
                     }
                 }, null);
             }
+
+            //connect keywebcam signal
+            Settings.settings.connect('changed::' + Settings.DEVICE_WEBCAM_SETTING_KEY,
+                Lang.bind(this, function() {
+                    Lib.TalkativeLog('-^-webcam device changed');
+                    this._refreshWebcamOptions();
+                })
+            );
         }
         Ref_filechooser_FileFolder.set_filename(tmpFolder);
-
-        Settings.settings.connect('changed::' + Settings.DEVICE_WEBCAM_SETTING_KEY,
-            Lang.bind(this, function() {
-                Lib.TalkativeLog('-^-webcam device changed');
-
-                this._updateStateWebcamOptions();
-            })
-        );
 
         Ref_filechooser_FileFolder.connect('file_set',
             (self) => {
@@ -775,9 +772,10 @@ const EasyScreenCastSettingsWidget = new GObject.Class({
     },
 
     _updateWebCamCaps: function(device) {
-        if (device > 0) {
-            Lib.TalkativeLog('-^-webcam device: ' + device);
+        Lib.TalkativeLog('-^-webcam device: ' + device);
 
+        if (device > 0) {
+            this._initializeWebcamHelper();
             var listCaps = this.CtrlWebcam.getListCapsDevice(device - 1);
             Lib.TalkativeLog('-^-webcam caps: ' + listCaps.length);
             if (listCaps !== null && listCaps !== undefined) {
@@ -797,19 +795,28 @@ const EasyScreenCastSettingsWidget = new GObject.Class({
         }
     },
 
+
     /**
      * Refreshes the webcam settings.
      */
     _refreshWebcamOptions: function () {
-        if (this.CtrlWebcam === null) {
-            this.CtrlWebcam = new UtilWebcam.HelperWebcam();
-        }
+        Lib.TalkativeLog('-^-refresh webcam options');
+        this._initializeWebcamHelper();
 
         //fill combobox with quality option webcam
         this._updateWebCamCaps(Settings.getOption('i', Settings.DEVICE_WEBCAM_SETTING_KEY));
 
         //update webcam widget state
         this._updateStateWebcamOptions();
+    },
+
+    /**
+     * Initializes this.CtrlWebcam if it is null.
+     */
+    _initializeWebcamHelper: function () {
+        if (this.CtrlWebcam === null) {
+            this.CtrlWebcam = new UtilWebcam.HelperWebcam();
+        }
     },
 
     _updateRowShortcut: function(accel) {

--- a/prefs.js
+++ b/prefs.js
@@ -45,7 +45,7 @@ const EasyScreenCastSettingsWidget = new GObject.Class({
         // creates the settings
         Settings.checkSettings();
 
-        this.CtrlWebcam = new UtilWebcam.HelperWebcam();
+        this.CtrlWebcam = null;
         this.CtrlExe = new UtilExeCmd.ExecuteStuff(null);
 
         // creates the ui builder and add the main resource file
@@ -503,7 +503,6 @@ const EasyScreenCastSettingsWidget = new GObject.Class({
                 }
             });
 
-
         //load file resolution pref and upadte UI
         var tmpRes= Settings.getOption('i',
             Settings.FILE_RESOLUTION_TYPE_SETTING_KEY);
@@ -647,6 +646,14 @@ const EasyScreenCastSettingsWidget = new GObject.Class({
         }
         Ref_filechooser_FileFolder.set_filename(tmpFolder);
 
+        Settings.settings.connect('changed::' + Settings.DEVICE_WEBCAM_SETTING_KEY,
+            Lang.bind(this, function() {
+                Lib.TalkativeLog('-^-webcam device changed');
+
+                this._updateStateWebcamOptions();
+            })
+        );
+
         Ref_filechooser_FileFolder.connect('file_set',
             (self) => {
                 var tmpPathFolder = self.get_filename();
@@ -788,6 +795,21 @@ const EasyScreenCastSettingsWidget = new GObject.Class({
             this.Ref_ListStore_QualityWebCam.clear();
             Settings.setOption(Settings.QUALITY_WEBCAM_SETTING_KEY, '');
         }
+    },
+
+    /**
+     * Refreshes the webcam settings.
+     */
+    _refreshWebcamOptions: function () {
+        if (this.CtrlWebcam === null) {
+            this.CtrlWebcam = new UtilWebcam.HelperWebcam();
+        }
+
+        //fill combobox with quality option webcam
+        this._updateWebCamCaps(Settings.getOption('i', Settings.DEVICE_WEBCAM_SETTING_KEY));
+
+        //update webcam widget state
+        this._updateStateWebcamOptions();
     },
 
     _updateRowShortcut: function(accel) {

--- a/utilwebcam.js
+++ b/utilwebcam.js
@@ -22,8 +22,6 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Lib = Me.imports.convenience;
 
-Gst.init(null);
-
 let ListDevices = null;
 let ListCaps = null;
 
@@ -34,6 +32,8 @@ const HelperWebcam = new Lang.Class({
      */
     _init: function() {
         Lib.TalkativeLog('-@-init webcam');
+
+        Gst.init(null);
 
         //get gstreamer lib version
         var [M, m, micro, nano] = Gst.version();


### PR DESCRIPTION
Currently the extension prevents the Gnome Wayland session
from starting. This seems to be caused by GStreamer initializing
too early.
This commit delays the calls to GStreamer in the extension and
the preferences until the user interacts with the widgets. At that
time GStreamer is ready to be called and the extension works as
expected.