### PR TITLE
Update "Display server" entry in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -41,5 +41,4 @@
 
 * Operating System and version:
 
-* Wayland or X?
-
+* Display server: Wayland / X11 / Other


### PR DESCRIPTION
Added a header to the display server entry. This makes it easier to search for display-specific issues. (Otherwise a search for "Wayland" returns all issues.)