### PR TITLE
Remove 2nd parameter from Gst.Caps.new_empty_simple

### DIFF
--- a/utilwebcam.js
+++ b/utilwebcam.js
@@ -63,7 +63,7 @@ const HelperWebcam = new Lang.Class({
             if (this.dmBus !== null && this.dmBus !== undefined) {
                 Lib.TalkativeLog('-@-dbus created');
                 this.dmBus.add_watch(GLib.PRIORITY_DEFAULT, this._getMsg);
-                let caps = Gst.Caps.new_empty_simple('video/x-raw', null);
+                let caps = Gst.Caps.new_empty_simple('video/x-raw');
                 this.deviceMonitor.add_filter('Video/Source', caps);
 
                 //update device and caps


### PR DESCRIPTION
The 2nd parameter causes a warning.

Fixes: #176