### PR TITLE
[metadata.json] add support to 3.30

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,8 @@
     "3.24",
     "3.26",
     "3.27",
-    "3.28"
+    "3.28",
+    "3.30"
   ],
   "uuid": "EasyScreenCast@iacopodeenosee.gmail.com",
   "url": "https://github.com/EasyScreenCast/EasyScreenCast",


### PR DESCRIPTION
Hello,
I'm working on packaging this extension on Debian, based on Kali's work, and I see they are patching metadata.json to support gnome 3.30.

Thanks.