### PR TITLE
Gnome 3.3x compatibility fix.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -527,7 +527,7 @@ const EasyScreenCast_Indicator = new Lang.Class({
         this.TimeSlider = new Slider.Slider(Settings.getOption('i',
             Settings.TIME_DELAY_SETTING_KEY) / 100);
         this.TimeSlider.connect(
-            'value-changed', (item) => {
+            'notify::value', (item) => {
                 this.DelayTimeLabel.set_text(
                     Math.floor(item.value * 100).toString() + _(' Sec'));
             });

--- a/prefs.js
+++ b/prefs.js
@@ -284,7 +284,7 @@ const EasyScreenCastSettingsWidget = new GObject.Class({
         Ref_scale_Quality.set_value(Settings.getOption(
             'i', Settings.QUALITY_SETTING_KEY));
 
-        Ref_scale_Quality.connect('value-changed',
+        Ref_scale_Quality.connect('notify::value',
             (self) => {
                 Lib.TalkativeLog('-^-value quality changed : ' + self.get_value());
 

--- a/selection.js
+++ b/selection.js
@@ -62,7 +62,7 @@ const Capture = new Lang.Class({
 
         this.monitor = Main.layoutManager.focusMonitor;
 
-        this._areaSelection = new Shell.GenericContainer({
+        this._areaSelection = new St.Widget({
             name: 'area-selection',
             style_class: 'area-selection',
             visible: 'true',
@@ -405,7 +405,7 @@ const AreaRecording = new Lang.Class({
     _init: function () {
         Lib.TalkativeLog('-£-area recording init');
 
-        this._areaRecording = new Shell.GenericContainer({
+        this._areaRecording = new St.Widget({
             name: 'area-recording',
             style_class: 'area-recording',
             visible: 'true',


### PR DESCRIPTION
Deprecate `Shell.GenericContainer` in `gnome-shell` 3.30
https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/153
Fix #224 #225

Actorized animation objects in `gnome-shell` 3.34
https://gitlab.gnome.org/GNOME/gnome-shell/commit/3d3dca4aa2e92f3b41bbd40e8bbc8992aeda1303

Fix #237 #238 #233