### PR TITLE
Use the standard ByteArray.toString conversion

### DIFF
--- a/utilexecmd.js
+++ b/utilexecmd.js
@@ -10,6 +10,7 @@
     FOR A PARTICULAR PURPOSE.  See the GNU GPL for more details.
 */
 
+const ByteArray = imports.byteArray;
 const Lang = imports.lang;
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
@@ -145,12 +146,12 @@ var ExecuteStuff = new Lang.Class({
             }
             if (successS) {
                 Lib.TalkativeLog('-¶-argv: ' + argv);
-                Lib.TalkativeLog('-¶-std_out: ' + std_out);
-                Lib.TalkativeLog('-¶-std_err: ' + std_err);
+                Lib.TalkativeLog('-¶-std_out: ' + ByteArray.toString(std_out));
+                Lib.TalkativeLog('-¶-std_err: ' + ByteArray.toString(std_err));
 
                 Lib.TalkativeLog('-¶-exe RC');
                 if (this.Callback !== null) {
-                    this.Callback.apply(this.Scope, [true, std_out.toString()]);
+                    this.Callback.apply(this.Scope, [true, ByteArray.toString(std_out)]);
                 }
             } else {
                 Lib.TalkativeLog('-¶-ERROR exe WC');


### PR DESCRIPTION
This addresses the following warning:

Some code called array.toString() on a Uint8Array instance. Previously
this would have interpreted the bytes of the array as a string, but that
is nonstandard. In the future this will return the bytes as
comma-separated digits. For the time being, the old behavior has been
preserved, but please fix your code anyway to explicitly call
ByteArray.toString(array).

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>