### PR TITLE
Display version in prefs dialog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,4 +105,5 @@ _build: versioninfo all
 		mkdir -p $$lf/LC_MESSAGES; \
 		cp $$l $$lf/LC_MESSAGES/$(UUID).mo; \
 	done
-	sed -i 's/"version": "[0-9]\{1,\}"/"version": "$(NEXT_EXTENSION_VERSION)"/'  _build/metadata.json
+	jq 'setpath(["version"]; "'$(NEXT_EXTENSION_VERSION)'")' metadata.json > _build/metadata.json
+	jq 'setpath(["fullversion"]; "'$(VERSION)'")' package.json > _build/package.json

--- a/convenience.js
+++ b/convenience.js
@@ -27,6 +27,7 @@
 const Gettext = imports.gettext;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
+const ByteArray = imports.byteArray;
 
 const Config = imports.misc.config;
 const ExtensionUtils = imports.misc.extensionUtils;
@@ -115,6 +116,18 @@ function TalkativeLog(msg) {
     if (Settings.getOption("b", Settings.VERBOSE_DEBUG_SETTING_KEY)) {
         log("[ESC]" + msg);
     }
+}
+
+/**
+ * Loads the file package.json
+ *
+ * @returns {Object} package.json
+ */
+function loadPackageJson() {
+    let packageJsonFile = Gio.File.new_for_path(Me.dir.get_child("package.json").get_path())
+    let [_, contents] = packageJsonFile.load_contents(null);
+    let packageJson = JSON.parse(ByteArray.toString(contents));
+    return packageJson;
 }
 
 var ESConGIcon = new Gio.FileIcon({

--- a/extension.js
+++ b/extension.js
@@ -39,6 +39,7 @@ const UtilWebcam = Me.imports.utilwebcam;
 const UtilNotify = Me.imports.utilnotify;
 const Selection = Me.imports.selection;
 const UtilExeCmd = Me.imports.utilexecmd;
+const Gio = imports.gi.Gio;
 
 var Indicator;
 let timerD = null;
@@ -1021,6 +1022,7 @@ function init(meta) {
     Lib.TalkativeLog("-*-initExtension called");
     Lib.TalkativeLog("-*-version: " + meta.metadata.version);
     Lib.TalkativeLog("-*-install path: " + meta.path);
+    Lib.TalkativeLog(`-*-version (package.json): ${Lib.loadPackageJson().version}`);
 
     Lib.initTranslations("EasyScreenCast@iacopodeenosee.gmail.com");
 }

--- a/extension.js
+++ b/extension.js
@@ -1022,7 +1022,7 @@ function init(meta) {
     Lib.TalkativeLog("-*-initExtension called");
     Lib.TalkativeLog("-*-version: " + meta.metadata.version);
     Lib.TalkativeLog("-*-install path: " + meta.path);
-    Lib.TalkativeLog(`-*-version (package.json): ${Lib.loadPackageJson().version}`);
+    Lib.TalkativeLog(`-*-version (package.json): ${Lib.loadPackageJson().fullversion}`);
 
     Lib.initTranslations("EasyScreenCast@iacopodeenosee.gmail.com");
 }

--- a/prefs.js
+++ b/prefs.js
@@ -1013,7 +1013,7 @@ const EasyScreenCastSettingsWidget = new GObject.Class({
             _("Version: ") +
                 '<span color="blue">' +
                 Me.metadata.version +
-                "</span>"
+                "</span>" + ` (${Lib.loadPackageJson().version})`
         );
     },
 

--- a/prefs.js
+++ b/prefs.js
@@ -1013,7 +1013,7 @@ const EasyScreenCastSettingsWidget = new GObject.Class({
             _("Version: ") +
                 '<span color="blue">' +
                 Me.metadata.version +
-                "</span>" + ` (${Lib.loadPackageJson().version})`
+                "</span>" + ` (${Lib.loadPackageJson().fullversion})`
         );
     },
 


### PR DESCRIPTION
Example of a dev version. The extension version is 43, the actual version in package.json is 1.4.0 and there are two more commits landing at 54d9ce6 ...

![grafik](https://user-images.githubusercontent.com/1573684/141524125-363f3887-958b-4e0a-a02a-e5d98405af5e.png)
