### PR TITLE
Add a custom _generateFileName function in utilrecorder (#188)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ At least gnome-shell 3.38 is required. This version of EasyScreenCast is not com
 * [#297](https://github.com/EasyScreenCast/EasyScreenCast/pull/297): Add eslint rules ([@adangel](https://github.com/adangel))
 * [#302](https://github.com/EasyScreenCast/EasyScreenCast/pull/302): Use ExtensionUtils for initTranslations and getSettings ([@adangel](https://github.com/adangel))
 * [#303](https://github.com/EasyScreenCast/EasyScreenCast/pull/303): Display version in prefs dialog ([@adangel](https://github.com/adangel))
+* [#306](https://github.com/EasyScreenCast/EasyScreenCast/pull/306): Add a custom _generateFileName function in utilrecorder (#188) ([@adangel](https://github.com/adangel))
 
 **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ At least gnome-shell 3.38 is required. This version of EasyScreenCast is not com
 **Fixes**
 
 * [#130](https://github.com/EasyScreenCast/EasyScreenCast/issues/130): Argument 'accelerator' but got type 'undefined' when loading the preferences dialog
+* [#188](https://github.com/EasyScreenCast/EasyScreenCast/issues/188): Improve filename template for the date and time format
 * [#299](https://github.com/EasyScreenCast/EasyScreenCast/issues/299): Review results from extensions.gnome.org
 
 # v1.4.0 (42) (2021-10-22)

--- a/utilrecorder.js
+++ b/utilrecorder.js
@@ -94,6 +94,8 @@ var CaptureVideo = GObject.registerClass({
         }
 
         Lib.TalkativeLog(`-&-path/file template : ${fileRec}`);
+        fileRec = this._generateFileName(fileRec);
+        Lib.TalkativeLog(`-&-path/file final : ${fileRec}`);
         if (shellVersion >= 40) {
             // prefix with a videoconvert element
             // see DEFAULT_PIPELINE in https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/dbusServices/screencast/screencastService.js#L26
@@ -184,5 +186,13 @@ var CaptureVideo = GObject.registerClass({
 
             return true;
         });
+    }
+
+    _generateFileName(template) {
+        template = template.replaceAll('%d', '%0x').replaceAll('%t', '%0X');
+        const datetime = GLib.DateTime.new_now_local();
+        const result = datetime.format(template);
+        const withoutWhitespace = result.replaceAll(' ', '_');
+        return withoutWhitespace;
     }
 });


### PR DESCRIPTION
This replaces the default gnome shell functionality allowing
more flexibility: E.g. now all the placeholder of GLib.DateTime.format
are possible - with the exception of `%d` and `%t`, which keep their
old behaviour.

Additionally, whitespaces are replaced by underscore.

This make it possible to use now the template
`Screencast_%Y%m%0e_%H%M%S` in order to get a filename like
`Screencast_20171230_091325.webm`.

(Note: `%0e` needs to be used instead of `%d` for compatibility).

Fixes #188 