### PR TITLE
Fix [ESC] does not abort Window / Area Selection

### DIFF
--- a/selection.js
+++ b/selection.js
@@ -121,7 +121,7 @@ const Capture = GObject.registerClass({
      */
     _onCaptureEvent(actor, event) {
         if (event.type() === Clutter.EventType.KEY_PRESS) {
-            if (event.get_key_symbol() === Clutter.Escape) {
+            if (event.get_key_symbol() === Clutter.KEY_Escape) {
                 this._stop();
             }
         }


### PR DESCRIPTION
Use Clutter.KEY_Escape instead of Clutter.Escape

`Clutter.Escape` does not exist for new clutter versions [1] [2] and `Clutter.KEY_Escape` exists for old Clutter versions [3], so this shall be a safe change

[1]: https://gjs-docs.gnome.org/clutter8~8_api/clutter.key_escape
[2]: https://gjs-docs.gnome.org/clutter8~8_api/clutter.escape
[3]: https://gjs-docs.gnome.org/clutter10~1.26.4/clutter.key_escape