### PR TITLE
Only consider video/x-raw capabilities

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -411,7 +411,7 @@ const EasyScreenCastSettingsWidget = GObject.registerClass({
      * @private
      */
     _initTabWebcam(ctx, gtkDB, tmpS) {
-        // implements webcam quality option
+        // implements webcam quality option: Type: GtkListStore
         ctx.Ref_ListStore_QualityWebCam = gtkDB.get_object(
             'liststore_QualityWebCam'
         );
@@ -974,6 +974,7 @@ const EasyScreenCastSettingsWidget = GObject.registerClass({
             var listCaps = this.CtrlWebcam.getListCapsDevice(device - 1);
             Lib.TalkativeLog(`-^-webcam caps: ${listCaps.length}`);
             if (listCaps !== null && listCaps !== undefined) {
+                this.Ref_ListStore_QualityWebCam.clear();
                 for (var index in listCaps) {
                     this.Ref_ListStore_QualityWebCam.set(
                         this.Ref_ListStore_QualityWebCam.append(),

--- a/utilrecorder.js
+++ b/utilrecorder.js
@@ -191,8 +191,9 @@ var CaptureVideo = GObject.registerClass({
     _generateFileName(template) {
         template = template.replaceAll('%d', '%0x').replaceAll('%t', '%0X');
         const datetime = GLib.DateTime.new_now_local();
-        const result = datetime.format(template);
-        const withoutWhitespace = result.replaceAll(' ', '_');
-        return withoutWhitespace;
+        let result = datetime.format(template);
+        result = result.replaceAll(' ', '_'); // remove white space
+        result = result.replaceAll('/', '_'); // remove path separators
+        return result;
     }
 });


### PR DESCRIPTION
* Unroll framerates, if there are multiple options. Previously only one framerate was available.
* Fix filename pattern to avoid invalid filenames.
* Clear the capabilities list in the preferences before displaying/appending available capabilities.
* Fixes #316 