### PR TITLE
Add missing toString methods in selection classes

### DIFF
--- a/selection.js
+++ b/selection.js
@@ -196,6 +196,10 @@ const Capture = GObject.registerClass({
 
         Ext.Indicator._doDelayAction();
     }
+
+    toString() {
+        return this.GTypeName;
+    }
 });
 
 Signals.addSignalMethods(Capture.prototype);
@@ -244,6 +248,10 @@ var SelectionArea = GObject.registerClass({
                 this._capture._saveRect(rect.x, rect.y, rect.h, rect.w);
             }
         }
+    }
+
+    toString() {
+        return this.GTypeName;
     }
 });
 
@@ -340,6 +348,10 @@ var SelectionWindow = GObject.registerClass({
         Lib.TalkativeLog('-£-window highlight off');
         this._capture.clearSelection();
     }
+
+    toString() {
+        return this.GTypeName;
+    }
 });
 
 Signals.addSignalMethods(SelectionWindow.prototype);
@@ -394,6 +406,10 @@ var SelectionDesktop = GObject.registerClass({
 
             this._capture._saveRect(x, y, height, width);
         }
+    }
+
+    toString() {
+        return this.GTypeName;
     }
 });
 
@@ -473,6 +489,10 @@ var AreaRecording = GObject.registerClass({
      */
     isVisible() {
         return this._visible;
+    }
+
+    toString() {
+        return this.GTypeName;
     }
 });
 

--- a/selection.js
+++ b/selection.js
@@ -79,16 +79,19 @@ const Capture = GObject.registerClass({
 
         Main.uiGroup.add_actor(this._areaResolution);
 
-        if (Main.pushModal(this._areaSelection)) {
-            this._signalCapturedEvent = global.stage.connect(
-                'captured-event',
-                this._onCaptureEvent.bind(this)
-            );
-
-            this._setCaptureCursor();
-        } else {
-            Lib.TalkativeLog('-£-Main.pushModal() === false');
+        this._signalCapturedEvent = global.stage.connect(
+            'captured-event',
+            this._onCaptureEvent.bind(this)
+        );
+        this._prevFocus = global.stage.get_key_focus();
+        if (this._prevFocus !== null) {
+            this._prevFocusDestroyId = this._prevFocus.connect('destroy', () => {
+                this._prevFocus = null;
+            });
         }
+        global.stage.set_key_focus(this._areaSelection);
+
+        this._setCaptureCursor();
 
         Main.sessionMode.connect('updated', () => this._updateDraw());
     }
@@ -122,6 +125,7 @@ const Capture = GObject.registerClass({
     _onCaptureEvent(actor, event) {
         if (event.type() === Clutter.EventType.KEY_PRESS) {
             if (event.get_key_symbol() === Clutter.KEY_Escape) {
+                Lib.TalkativeLog('-£-capture selection stop with KEY_Escape');
                 this._stop();
             }
         }
@@ -179,7 +183,11 @@ const Capture = GObject.registerClass({
         global.stage.disconnect(this._signalCapturedEvent);
         this._setDefaultCursor();
         Main.uiGroup.remove_actor(this._areaSelection);
-        Main.popModal(this._areaSelection);
+        if (this._prevFocus) {
+            this._prevFocus.disconnect(this._prevFocusDestroyId);
+            global.stage.set_key_focus(this._prevFocus);
+            this._prevFocus = null;
+        }
         Main.uiGroup.remove_actor(this._areaResolution);
         this._areaSelection.destroy();
         this.emit('stop');


### PR DESCRIPTION
- Fixes #325 

I tried to use the signal methods from GObject, but this didn't work out at all. So I kept the old `Signals.addSignalMethods` solution.

After that, the extension loaded, but no area could be selected. It has something to do with `Main.pushModal` which doesn't behave the same with gnome shell 42 anymore.