### PR TITLE
Keybinding: Remove MESSAGE_TRAY, add SYSTEM_MODAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 **🐛 Fixed bugs:**
 
+* [#267](https://github.com/EasyScreenCast/EasyScreenCast/issues/267): JS Warning: undefined property "MESSAGE_TRAY"
+
 **Full Changelog**: <https://github.com/EasyScreenCast/EasyScreenCast/compare/1.6.3...HEAD>
 
 # v1.6.3 (45) (2022-05-19)

--- a/extension.js
+++ b/extension.js
@@ -912,10 +912,11 @@ const EasyScreenCastIndicator = GObject.registerClass({
                 Settings.SHORTCUT_KEY_SETTING_KEY,
                 this._settings._settings,
                 Meta.KeyBindingFlags.NONE,
+                // available modes: https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/src/shell-action-modes.h
                 Shell.ActionMode.NORMAL |
-                    Shell.ActionMode.MESSAGE_TRAY |
                     Shell.ActionMode.OVERVIEW |
-                    Shell.ActionMode.POPUP,
+                    Shell.ActionMode.POPUP |
+                    Shell.ActionMode.SYSTEM_MODAL,
                 () => {
                     Lib.TalkativeLog('-*-intercept key combination');
                     this._doRecording();


### PR DESCRIPTION
MESSAGE_TRAY has been removed a couple of years ago already from gnome shell (https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/890a80902267befd30711770b8488072fcc8a9b7).

Allow keybinding in SYSTEM_MODAL mode.

Fixes #267