### PR TITLE
Support GNOME Shell 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": [ "46" ],
+  "shell-version": [ "46", "47" ],
   "uuid": "EasyScreenCast@iacopodeenosee.gmail.com",
   "gettext-domain": "EasyScreenCast@iacopodeenosee.gmail.com",
   "settings-schema": "org.gnome.shell.extensions.EasyScreenCast",


### PR DESCRIPTION
GNOME 47 is scheduled for release on Wednesday.

I did a very simple smoketest with this change on Debian with gnome-shell 47.rc

See also https://gjs.guide/extensions/upgrading/gnome-shell-47.html