### PR TITLE
Support GNOME Shell 48

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": [ "46", "47" ],
+  "shell-version": [ "46", "47", "48" ],
   "uuid": "EasyScreenCast@iacopodeenosee.gmail.com",
   "gettext-domain": "EasyScreenCast@iacopodeenosee.gmail.com",
   "settings-schema": "org.gnome.shell.extensions.EasyScreenCast",


### PR DESCRIPTION
I did a minimal test with GNOME Shell 48 Beta from Debian Experimental (GNOME Shell 48 Beta is also available in Ubuntu 25.04) and the extension seemed to work.

See https://gjs.guide/extensions/upgrading/gnome-shell-48.html