### PR TITLE
Initial GNOME 50 support

### DIFF
--- a/display_module.js
+++ b/display_module.js
@@ -28,11 +28,4 @@ export const DisplayApi = {
     display_geometry_for_index(displayIndex) {
         return this._display().get_monitor_geometry(displayIndex);
     },
-
-    /**
-     * @param {Meta.Cursor} cursor the new cursor to set
-     */
-    set_cursor(cursor) {
-        this._display().set_cursor(cursor);
-    },
 };

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": [ "48", "49" ],
+  "shell-version": [ "50" ],
   "uuid": "EasyScreenCast@iacopodeenosee.gmail.com",
   "gettext-domain": "EasyScreenCast@iacopodeenosee.gmail.com",
   "settings-schema": "org.gnome.shell.extensions.EasyScreenCast",

--- a/selection.js
+++ b/selection.js
@@ -23,7 +23,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 'use strict';
 
 import GObject from 'gi://GObject';
-import Meta from 'gi://Meta';
 import Clutter from 'gi://Clutter';
 import St from 'gi://St';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
@@ -86,14 +85,14 @@ class Capture extends Signals.EventEmitter {
      * @private
      */
     _setDefaultCursor() {
-        DisplayApi.set_cursor(Meta.Cursor.DEFAULT);
+        this._areaSelection.set_cursor_type(Clutter.CursorType.DEFAULT);
     }
 
     /**
      * @private
      */
     _setCaptureCursor() {
-        DisplayApi.set_cursor(Meta.Cursor.CROSSHAIR);
+        this._areaSelection.set_cursor_type(Clutter.CursorType.CROSSHAIR);
     }
 
     /**


### PR DESCRIPTION
- Extension is functional for recording - selection of Area / Window works
- The right click quick launch on the Panel button does not work and that requires wiring up the Clutter.ClickGesture and passing false while constructing the menu
  - But [this](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/main/js/ui/panelMenu.js?ref_type=heads#L128-143) seems problematic as only one clickgesture activates at a time