### PR TITLE
Fix #293: Make recording-area border click-through via a hollow frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 **🚀 Implemented enhancements:**
 
 **🎉 Merged pull requests:**
+* [#392](https://github.com/EasyScreenCast/EasyScreenCast/pull/392): Fix #293: Make recording-area border click-through via a hollow frame ([@RandyHaylor](https://github.com/RandyHaylor))
 
 **🐛 Fixed bugs:**
+* [#24](https://github.com/EasyScreenCast/EasyScreenCast/issues/24): Showing the recording area rectangle breaks the mouse clicks ([@nekohayo](https://github.com/nekohayo))
+* [#293](https://github.com/EasyScreenCast/EasyScreenCast/issues/293): Cursor does not work when showing recording area ([@antonio24073](https://github.com/antonio24073))
 
 **📦 Dependency updates:**
 

--- a/selection.js
+++ b/selection.js
@@ -378,31 +378,49 @@ export const AreaRecording = GObject.registerClass({
         super();
         Lib.TalkativeLog('-£-area recording init');
 
-        this._areaRecording = new St.Widget({
-            name: 'area-recording',
-            style_class: 'area-recording',
-            visible: 'true',
-            reactive: 'false',
-            x: -10,
-            y: -10,
-        });
+        // The recording-area indicator is drawn as a hollow frame made of four
+        // thin edge strips (top/bottom/left/right) rather than a single widget
+        // covering the whole recorded rectangle.
+        //
+        // Two problems are fixed here:
+        //  1. The previous widget used the strings 'true'/'false' for
+        //     visible/reactive. A non-empty string is truthy in JS, so
+        //     reactive:'false' made the indicator REACTIVE: it covered the whole
+        //     region and swallowed every pointer event, so nothing inside the
+        //     recorded area could be clicked (issue #24).
+        //  2. Even once made non-reactive, a single actor spanning the whole
+        //     region still interferes with click-to-focus/raise of non-focused
+        //     windows beneath it. Four edge strips leave the interior free of
+        //     any actor, so clicks inside behave as if no indicator were present.
+        this._borderThickness = 2;
+        this._edges = [];
+        for (let edgeIndex = 0; edgeIndex < 4; edgeIndex++) {
+            const edge = new St.Widget({
+                name: 'area-recording',
+                style_class: 'area-recording-edge',
+                visible: true,
+                reactive: false,
+                x: -10,
+                y: -10,
+            });
+            Main.uiGroup.add_child(edge);
+            this._edges.push(edge);
+        }
 
         let [recX, recY, recW, recH] = Ext.Indicator.getSelectedRect();
         let tmpH = Main.layoutManager.currentMonitor.height;
         let tmpW = Main.layoutManager.currentMonitor.width;
 
-        Main.uiGroup.add_child(this._areaRecording);
-
         Main.overview.connect('showing', () => {
             Lib.TalkativeLog('-£-overview opening');
 
-            Main.uiGroup.remove_child(this._areaRecording);
+            this._edges.forEach(edge => Main.uiGroup.remove_child(edge));
         });
 
         Main.overview.connect('hidden', () => {
             Lib.TalkativeLog('-£-overview closed');
 
-            Main.uiGroup.add_child(this._areaRecording);
+            this._edges.forEach(edge => Main.uiGroup.add_child(edge));
         });
 
         if (recX + recW <= tmpW - 5 && recY + recH <= tmpH - 5)
@@ -419,8 +437,30 @@ export const AreaRecording = GObject.registerClass({
         Lib.TalkativeLog('-£-draw area recording');
 
         this._visible = true;
-        this._areaRecording.set_position(x, y);
-        this._areaRecording.set_size(w, h);
+
+        // clearArea() passes w/h = 0 to hide the frame: collapse all strips.
+        if (w <= 0 || h <= 0) {
+            this._edges.forEach(edge => {
+                edge.set_position(-10, -10);
+                edge.set_size(0, 0);
+            });
+            return;
+        }
+
+        const t = this._borderThickness;
+        const [top, bottom, left, right] = this._edges;
+
+        top.set_position(x, y);
+        top.set_size(w, t);
+
+        bottom.set_position(x, y + h - t);
+        bottom.set_size(w, t);
+
+        left.set_position(x, y);
+        left.set_size(t, h);
+
+        right.set_position(x + w - t, y);
+        right.set_size(t, h);
     }
 
     /**

--- a/selection.js
+++ b/selection.js
@@ -380,18 +380,11 @@ export const AreaRecording = GObject.registerClass({
 
         // The recording-area indicator is drawn as a hollow frame made of four
         // thin edge strips (top/bottom/left/right) rather than a single widget
-        // covering the whole recorded rectangle.
-        //
-        // Two problems are fixed here:
-        //  1. The previous widget used the strings 'true'/'false' for
-        //     visible/reactive. A non-empty string is truthy in JS, so
-        //     reactive:'false' made the indicator REACTIVE: it covered the whole
-        //     region and swallowed every pointer event, so nothing inside the
-        //     recorded area could be clicked (issue #24).
-        //  2. Even once made non-reactive, a single actor spanning the whole
-        //     region still interferes with click-to-focus/raise of non-focused
-        //     windows beneath it. Four edge strips leave the interior free of
-        //     any actor, so clicks inside behave as if no indicator were present.
+        // covering the whole recorded rectangle. A single widget would swallow
+        // all events (including focus, pointer events), so nothing inside the
+        // recorded area could be clicked (see also issues #24, #293).
+        // Four edge strips leave the interior free of any actor, so clicks
+        // inside behave as if no indicator were present.
         this._borderThickness = 2;
         this._edges = [];
         for (let edgeIndex = 0; edgeIndex < 4; edgeIndex++) {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -8,11 +8,6 @@
     border: 2px solid rgba(255, 0, 0, 1);
 }
 
-.area-recording {
-    border-style: dashed;
-    border: 2px rgba(255, 0, 0, 1);
-}
-
 /* Edge strip of the hollow recording-area frame (see AreaRecording in
    selection.js). The frame is built from four of these 2px strips so it marks
    the recorded area without covering its interior. */

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -13,6 +13,13 @@
     border: 2px rgba(255, 0, 0, 1);
 }
 
+/* Edge strip of the hollow recording-area frame (see AreaRecording in
+   selection.js). The frame is built from four of these 2px strips so it marks
+   the recorded area without covering its interior. */
+.area-recording-edge {
+    background-color: rgba(255, 0, 0, 1);
+}
+
 .alert-msg {
     font-size: 40px;
     font-weight: bold;


### PR DESCRIPTION
## Problem

When "show area during recording" is enabled, the recording-area indicator
**captures all mouse input over the recorded region**, so nothing inside the
area can be clicked while recording (issue #24).

Root cause: in `AreaRecording` (`selection.js`) the indicator widget is created
with **string** literals:

```js
visible: 'true',
reactive: 'false',
```

A non-empty string is truthy in JS, so `reactive: 'false'` actually makes the
widget **reactive**. Sized to the whole recorded rectangle, it sits in
`Main.uiGroup` above the windows and swallows every pointer event in the area.

Making it non-reactive is necessary but **not sufficient**: a single actor
spanning the whole region still interferes with click-to-focus/raise of
**non-focused** windows beneath it.

## Fix

Redraw the indicator as a **hollow frame built from four thin edge strips**
(top/bottom/left/right), all non-reactive, leaving the interior free of any
actor. Clicks inside the recorded area then behave as if no indicator were
present, while the frame still marks the area.

- `selection.js`: `AreaRecording` builds four non-reactive edge strips and lays
  them out in `drawArea()`; `clearArea()` collapses them offscreen.
- `stylesheet.css`: add `.area-recording-edge` (solid 2px red strip). The frame
  is solid rather than dashed, since dashes are not meaningful on a 2px strip.

## Testing — please read (honest scope)

- ✅ **Behaviorally validated** by backporting the identical logic to the
  published v47 build running on **GNOME Shell 42 (X11)**: the recording-area
  border is visible, clicks pass through to the focused window, and clicking a
  **non-focused** window inside the area now focuses/raises it.
- ✅ `eslint .` (repo config) passes on the changed file.
- ⚠️ **Not runtime-tested on GNOME Shell 50 / current `master`.** I don't have a
  GNOME 50 environment; this `master` port is the same logic adapted to the ESM
  code, lint-clean, but I have not run it on GNOME 50. A maintainer check on a
  current shell would be appreciated before merge.

Happy to adjust style (e.g. strip thickness/colour, or keep a dashed look via a
different approach) if preferred.

## Related issues
- Fix #293 
- Fix #24 
- Maybe #250
- Maybe #220
