### PR TITLE
Bump gh-actions and node

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - name: Use Node.js 20
-      uses: actions/setup-node@v4
+    - name: Use Node.js 24
+      uses: actions/setup-node@v6
       with:
-        node-version: 20
+        node-version: 24
         cache: 'npm'
     - name: Install gettext, intltool and jq
       run: |
@@ -28,7 +28,7 @@ jobs:
     - run: npm ci
     - run: npm run lint
     - run: make zip-file
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: EasyScreenCast
         path: EasyScreenCast_*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **🎉 Merged pull requests:**
 * [#392](https://github.com/EasyScreenCast/EasyScreenCast/pull/392): Fix #293: Make recording-area border click-through via a hollow frame ([@RandyHaylor](https://github.com/RandyHaylor))
+* [#393](https://github.com/EasyScreenCast/EasyScreenCast/pull/393): Bump gh-actions and node ([@adangel](https://github.com/adangel))
 
 **🐛 Fixed bugs:**
 * [#24](https://github.com/EasyScreenCast/EasyScreenCast/issues/24): Showing the recording area rectangle breaks the mouse clicks ([@nekohayo](https://github.com/nekohayo))


### PR DESCRIPTION
- actions/checkout from v4 to v6
- actions/setup-node from v4 to v6
- actions/upload-artifact from v4 to v7
- node from 20 to 24