### PR TITLE
Fail-safe cleanup of the recording-area frame

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -617,6 +617,12 @@ const EasyScreenCastIndicator = GObject.registerClass({
         // unregister mixer control
         this.CtrlAudio.destroy();
 
+        // Fail-safe: tear down any recording-area frame so disabling the
+        // extension (or GNOME Shell unloading it) can never leave stuck red
+        // border artifacts on screen.
+        if (this.recorder)
+            this.recorder.clearAreaRecording();
+
         // remove indicator
         this.remove_child(this.indicatorBox);
     }

--- a/selection.js
+++ b/selection.js
@@ -404,13 +404,16 @@ export const AreaRecording = GObject.registerClass({
         let tmpH = Main.layoutManager.currentMonitor.height;
         let tmpW = Main.layoutManager.currentMonitor.width;
 
-        Main.overview.connect('showing', () => {
+        // Keep the handler IDs so destroy() can disconnect them; otherwise the
+        // handlers (and the actors they capture) leak and can fire against
+        // already-destroyed actors.
+        this._overviewShowingId = Main.overview.connect('showing', () => {
             Lib.TalkativeLog('-£-overview opening');
 
             this._edges.forEach(edge => Main.uiGroup.remove_child(edge));
         });
 
-        Main.overview.connect('hidden', () => {
+        this._overviewHiddenId = Main.overview.connect('hidden', () => {
             Lib.TalkativeLog('-£-overview closed');
 
             this._edges.forEach(edge => Main.uiGroup.add_child(edge));
@@ -457,13 +460,45 @@ export const AreaRecording = GObject.registerClass({
     }
 
     /**
-     * Clears the drawing area
+     * Fully removes the recording-area frame and releases its resources:
+     * disconnects the overview signal handlers and removes + destroys every
+     * edge actor. Idempotent and fail-safe (safe to call repeatedly and whether
+     * or not the frame is shown). Prevents stuck red-border artifacts when a
+     * recording ends abnormally or the extension is disabled mid-recording.
+     */
+    destroy() {
+        Lib.TalkativeLog('-£-destroy area recording');
+
+        this._visible = false;
+
+        if (this._overviewShowingId) {
+            Main.overview.disconnect(this._overviewShowingId);
+            this._overviewShowingId = null;
+        }
+        if (this._overviewHiddenId) {
+            Main.overview.disconnect(this._overviewHiddenId);
+            this._overviewHiddenId = null;
+        }
+
+        if (this._edges) {
+            this._edges.forEach(edge => {
+                if (edge.get_parent() !== null)
+                    Main.uiGroup.remove_child(edge);
+
+                edge.destroy();
+            });
+            this._edges = [];
+        }
+    }
+
+    /**
+     * Clears the drawing area. Delegates to destroy() so the frame actors are
+     * actually removed, not just hidden offscreen.
      */
     clearArea() {
         Lib.TalkativeLog('-£-hide area recording');
 
-        this._visible = false;
-        this.drawArea(-10, -10, 0, 0);
+        this.destroy();
     }
 
     /**

--- a/utilrecorder.js
+++ b/utilrecorder.js
@@ -52,6 +52,32 @@ export const CaptureVideo = GObject.registerClass({
                     Lib.TalkativeLog('-&-d-bus proxy connected');
             }
         );
+
+        // Fail-safe for an abnormal backend death: if the screencast service
+        // process disappears (crash/kill) no Stop call ever reaches us, so the
+        // recording-area frame would stay stuck on screen. Watch the D-Bus name;
+        // when it vanishes while a frame is shown, tear the frame down.
+        this._screencastWatchId = Gio.bus_watch_name(
+            Gio.BusType.SESSION,
+            'org.gnome.Shell.Screencast',
+            Gio.BusNameWatcherFlags.NONE,
+            null,
+            () => {
+                Lib.TalkativeLog('-&-screencast bus name vanished -> clear frame');
+                this.clearAreaRecording();
+            }
+        );
+    }
+
+    /**
+     * Fail-safe removal of the recording-area frame. Idempotent: safe to call
+     * when no frame exists, and safe to call repeatedly.
+     */
+    clearAreaRecording() {
+        if (this.AreaSelected !== null) {
+            this.AreaSelected.destroy();
+            this.AreaSelected = null;
+        }
     }
 
     /**
@@ -168,8 +194,12 @@ export const CaptureVideo = GObject.registerClass({
                         Lib.TalkativeLog(`-&-screencast execute - ${result[0]} - ${result[1]}`);
 
                         // draw area recording
-                        if (Ext.Indicator.getSettings().getOption('b', Settings.SHOW_AREA_REC_SETTING_KEY))
+                        if (Ext.Indicator.getSettings().getOption('b', Settings.SHOW_AREA_REC_SETTING_KEY)) {
+                            // Remove any stale frame first so a second start can
+                            // never orphan a previous instance's actors.
+                            this.clearAreaRecording();
                             this.AreaSelected = new Selection.AreaRecording();
+                        }
 
                         let resultingFilePath = result[1];
                         if (resultingFilePath.endsWith('.undefined')) {
@@ -198,10 +228,8 @@ export const CaptureVideo = GObject.registerClass({
         this._screenCastService.StopScreencastRemote((result, error) => {
             if (error) {
                 Lib.TalkativeLog(`-&-ERROR(screencast stop) - ${error.message}`);
-                return false;
             } else {
                 Lib.TalkativeLog(`-&-screencast stop - ${result[0]}`);
-
 
                 // rename the file...
                 Lib.TalkativeLog(`-&-screencast: rename ${this._originalFilePath} to ${this._filePathWithExtension}`);
@@ -210,15 +238,16 @@ export const CaptureVideo = GObject.registerClass({
                 sourceFile.move(destFile, 0, null, null);
             }
 
-            // clear area recording
-            if (this.AreaSelected !== null && this.AreaSelected.isVisible())
-                this.AreaSelected.clearArea();
+            // Always clear the recording-area frame, on success OR error.
+            this.clearAreaRecording();
 
             if (callback)
                 callback();
-
-            return true;
         });
+
+        // Also clear synchronously, in case the async StopScreencast callback
+        // never fires (e.g. the screencast service has gone away). Idempotent.
+        this.clearAreaRecording();
     }
 
     // without file extension


### PR DESCRIPTION
Follow-up to #392. The area frame stays on screen whenever cleanup doesn't run — and cleanup only ran on the `StopScreencast` success path:

- errored or never-returning `StopScreencast` → frame never cleared
- `disable()` mid-recording → frame never cleared
- backend crash/kill → no Stop call at all → frame never cleared

Also, `clearArea()` collapsed the strips to size 0 instead of destroying them, and never disconnected the overview handlers (actor + handler leak).

**Fix:** real idempotent `destroy()` (selection.js) + `clearAreaRecording()` (utilrecorder.js); run it on stop success/error/sync, before re-create, on `_disable()`, and on `Gio.bus_watch_name` vanish (backend death).

**Testing:** backport validated on v47 / GNOME 42 — normal stop and backend-kill both clear the frame; `eslint` passes. Not runtime-tested on GNOME 50.
