### PR TITLE
Clear the recording-area frame when a recording start reports failure

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -41,6 +41,10 @@ let timerD = null;
 let timerC = null;
 
 let isActive = false;
+// True from when a recording start is initiated (selection overlay open or the
+// start awaiting its result) until it resolves. Used to ignore repeated hotkey
+// presses so they can't stack multiple selection overlays / start attempts.
+let isStartPending = false;
 let pathFile = '';
 
 let keybindingConfigured = false;
@@ -681,6 +685,17 @@ const EasyScreenCastIndicator = GObject.registerClass({
     _doRecording() {
         // start/stop record screen
         if (isActive === false) {
+            // Reentrancy guard: ignore the hotkey while a start is already in
+            // progress (selection overlay open, or start awaiting its result).
+            // Without this, repeated presses stack multiple selection overlays /
+            // start attempts. Cleared when the selection ends (finish or abort)
+            // and in doRecResult().
+            if (isStartPending) {
+                Lib.TalkativeLog('-*-start already pending - ignoring hotkey press');
+                return;
+            }
+            isStartPending = true;
+
             Lib.TalkativeLog('-*-start recording');
 
             pathFile = '';
@@ -689,16 +704,25 @@ const EasyScreenCastIndicator = GObject.registerClass({
             const optArea = this._settings.getOption('i', Settings.AREA_SCREEN_SETTING_KEY);
             if (optArea > 0) {
                 Lib.TalkativeLog(`-*-type of selection of the area to record: ${optArea}`);
+                let areaSelection = null;
                 switch (optArea) {
                 case 3:
-                    new Selection.SelectionArea();
+                    areaSelection = new Selection.SelectionArea();
                     break;
                 case 2:
-                    new Selection.SelectionWindow();
+                    areaSelection = new Selection.SelectionWindow();
                     break;
                 case 1:
-                    new Selection.SelectionDesktop();
+                    areaSelection = new Selection.SelectionDesktop();
                     break;
+                }
+                // Clear the pending guard once the selection overlay closes
+                // (whether the user finished selecting or aborted with ESC), so
+                // the guard can never get stuck and block future presses.
+                if (areaSelection) {
+                    areaSelection.connect('stop', () => {
+                        isStartPending = false;
+                    });
                 }
             } else {
                 Lib.TalkativeLog('-*-recording full area');
@@ -758,6 +782,9 @@ const EasyScreenCastIndicator = GObject.registerClass({
      * @param {string} file file path of the recorded file
      */
     doRecResult(result, file) {
+        // The start has resolved (success or failure): release the reentrancy guard.
+        isStartPending = false;
+
         if (result) {
             isActive = true;
 

--- a/extension.js
+++ b/extension.js
@@ -826,6 +826,10 @@ const EasyScreenCastIndicator = GObject.registerClass({
 
             pathFile = '';
 
+            // Fail-safe: whatever path drew a frame, a reported recording
+            // failure means no recording owns it any more.
+            this.recorder.clearAreaRecording();
+
             if (this.isShowNotify) {
                 Lib.TalkativeLog('-*-show error notify');
                 this.CtrlNotify.createNotify(

--- a/extension.js
+++ b/extension.js
@@ -617,6 +617,12 @@ const EasyScreenCastIndicator = GObject.registerClass({
         // unregister mixer control
         this.CtrlAudio.destroy();
 
+        // Fail-safe: tear down any recording-area frame so disabling the
+        // extension (or GNOME Shell unloading it) can never leave stuck red
+        // border artifacts on screen.
+        if (this.recorder)
+            this.recorder.clearAreaRecording();
+
         // remove indicator
         this.remove_child(this.indicatorBox);
     }

--- a/selection.js
+++ b/selection.js
@@ -404,13 +404,16 @@ export const AreaRecording = GObject.registerClass({
         let tmpH = Main.layoutManager.currentMonitor.height;
         let tmpW = Main.layoutManager.currentMonitor.width;
 
-        Main.overview.connect('showing', () => {
+        // Keep the handler IDs so destroy() can disconnect them; otherwise the
+        // handlers (and the actors they capture) leak and can fire against
+        // already-destroyed actors.
+        this._overviewShowingId = Main.overview.connect('showing', () => {
             Lib.TalkativeLog('-£-overview opening');
 
             this._edges.forEach(edge => Main.uiGroup.remove_child(edge));
         });
 
-        Main.overview.connect('hidden', () => {
+        this._overviewHiddenId = Main.overview.connect('hidden', () => {
             Lib.TalkativeLog('-£-overview closed');
 
             this._edges.forEach(edge => Main.uiGroup.add_child(edge));
@@ -457,13 +460,45 @@ export const AreaRecording = GObject.registerClass({
     }
 
     /**
-     * Clears the drawing area
+     * Fully removes the recording-area frame and releases its resources:
+     * disconnects the overview signal handlers and removes + destroys every
+     * edge actor. Idempotent and fail-safe (safe to call repeatedly and whether
+     * or not the frame is shown). Prevents stuck red-border artifacts when a
+     * recording ends abnormally or the extension is disabled mid-recording.
+     */
+    destroy() {
+        Lib.TalkativeLog('-£-destroy area recording');
+
+        this._visible = false;
+
+        if (this._overviewShowingId) {
+            Main.overview.disconnect(this._overviewShowingId);
+            this._overviewShowingId = null;
+        }
+        if (this._overviewHiddenId) {
+            Main.overview.disconnect(this._overviewHiddenId);
+            this._overviewHiddenId = null;
+        }
+
+        if (this._edges) {
+            this._edges.forEach(edge => {
+                if (edge.get_parent() !== null)
+                    Main.uiGroup.remove_child(edge);
+
+                edge.destroy();
+            });
+            this._edges = [];
+        }
+    }
+
+    /**
+     * Clears the drawing area. Delegates to destroy() so the frame actors are
+     * actually removed, not just hidden offscreen.
      */
     clearArea() {
         Lib.TalkativeLog('-£-hide area recording');
 
-        this._visible = false;
-        this.drawArea(-10, -10, 0, 0);
+        this.destroy();
     }
 
     /**

--- a/utilrecorder.js
+++ b/utilrecorder.js
@@ -52,6 +52,32 @@ export const CaptureVideo = GObject.registerClass({
                     Lib.TalkativeLog('-&-d-bus proxy connected');
             }
         );
+
+        // Fail-safe for an abnormal backend death: if the screencast service
+        // process disappears (crash/kill) no Stop call ever reaches us, so the
+        // recording-area frame would stay stuck on screen. Watch the D-Bus name;
+        // when it vanishes while a frame is shown, tear the frame down.
+        this._screencastWatchId = Gio.bus_watch_name(
+            Gio.BusType.SESSION,
+            'org.gnome.Shell.Screencast',
+            Gio.BusNameWatcherFlags.NONE,
+            null,
+            () => {
+                Lib.TalkativeLog('-&-screencast bus name vanished -> clear frame');
+                this.clearAreaRecording();
+            }
+        );
+    }
+
+    /**
+     * Fail-safe removal of the recording-area frame. Idempotent: safe to call
+     * when no frame exists, and safe to call repeatedly.
+     */
+    clearAreaRecording() {
+        if (this.AreaSelected !== null) {
+            this.AreaSelected.destroy();
+            this.AreaSelected = null;
+        }
     }
 
     /**
@@ -168,8 +194,12 @@ export const CaptureVideo = GObject.registerClass({
                         Lib.TalkativeLog(`-&-screencast execute - ${result[0]} - ${result[1]}`);
 
                         // draw area recording
-                        if (Ext.Indicator.getSettings().getOption('b', Settings.SHOW_AREA_REC_SETTING_KEY))
+                        if (Ext.Indicator.getSettings().getOption('b', Settings.SHOW_AREA_REC_SETTING_KEY)) {
+                            // Remove any stale frame first so a second start can
+                            // never orphan a previous instance's actors.
+                            this.clearAreaRecording();
                             this.AreaSelected = new Selection.AreaRecording();
+                        }
 
                         let resultingFilePath = result[1];
                         if (resultingFilePath.endsWith('.undefined')) {
@@ -198,10 +228,8 @@ export const CaptureVideo = GObject.registerClass({
         this._screenCastService.StopScreencastRemote((result, error) => {
             if (error) {
                 Lib.TalkativeLog(`-&-ERROR(screencast stop) - ${error.message}`);
-                return false;
             } else {
                 Lib.TalkativeLog(`-&-screencast stop - ${result[0]}`);
-
 
                 // rename the file...
                 Lib.TalkativeLog(`-&-screencast: rename ${this._originalFilePath} to ${this._filePathWithExtension}`);
@@ -210,15 +238,16 @@ export const CaptureVideo = GObject.registerClass({
                 sourceFile.move(destFile, 0, null, null);
             }
 
-            // clear area recording
-            if (this.AreaSelected !== null && this.AreaSelected.isVisible())
-                this.AreaSelected.clearArea();
+            // Always clear the recording-area frame, on success OR error.
+            this.clearAreaRecording();
 
             if (callback)
                 callback();
-
-            return true;
         });
+
+        // Also clear synchronously, in case the async StopScreencast callback
+        // never fires (e.g. the screencast service has gone away). Idempotent.
+        this.clearAreaRecording();
     }
 
     // without file extension

--- a/utilrecorder.js
+++ b/utilrecorder.js
@@ -193,13 +193,15 @@ export const CaptureVideo = GObject.registerClass({
                     } else {
                         Lib.TalkativeLog(`-&-screencast execute - ${result[0]} - ${result[1]}`);
 
-                        // draw area recording
-                        if (Ext.Indicator.getSettings().getOption('b', Settings.SHOW_AREA_REC_SETTING_KEY)) {
-                            // Remove any stale frame first so a second start can
-                            // never orphan a previous instance's actors.
-                            this.clearAreaRecording();
+                        const recordingStarted = result[0];
+
+                        // A start that reported failure must never leave a frame
+                        // on screen, and a start that succeeded must never
+                        // inherit the previous attempt's actors.
+                        this.clearAreaRecording();
+
+                        if (recordingStarted && Ext.Indicator.getSettings().getOption('b', Settings.SHOW_AREA_REC_SETTING_KEY))
                             this.AreaSelected = new Selection.AreaRecording();
-                        }
 
                         let resultingFilePath = result[1];
                         if (resultingFilePath.endsWith('.undefined')) {


### PR DESCRIPTION
## Problem

A failed recording start could leave the red recording-area frame stuck on screen indefinitely, and once that happened the record hotkey stopped working as a toggle — every press opened a **new** area selection instead of ending the (nonexistent) recording.

## Root cause

`ScreencastArea`/`Screencast` can return `success = false` **with no D-Bus error**. In `CaptureVideo.start()` the callback treated "no D-Bus error" as "recording started": the `else` branch constructed `Selection.AreaRecording()` before anything inspected `result[0]`, then handed the real result to `doRecResult()`.

Two consequences:

1. A frame was drawn for a recording that never started, and nothing owned it. `doRecResult()`'s failure branch only logged `record ERROR` and raised a notification — it never cleared the frame. The existing `stop()` and `_disable()` fail-safes never ran, because no recording was ever active to stop.
2. `isActive` is only set `true` in `doRecResult()`'s success branch, so it stayed `false`. The hotkey handler branches on `isActive === false` into the *start* path, so every subsequent press began a fresh area selection rather than stopping.

Captured from the GNOME Shell journal on the failing path:

```
-&-screencast execute - false -
-£-destroy area recording
-£-area recording init
-£-draw area recording      <- frame drawn for a start that reported failure
-*-record ERROR             <- nothing clears it
-*-refresh indicator -A false
```

## Fix

**`utilrecorder.js`** — only draw the frame once the start is known to have succeeded, and clear any stale frame unconditionally first:

```js
const recordingStarted = result[0];

this.clearAreaRecording();

if (recordingStarted && …SHOW_AREA_REC_SETTING_KEY…)
    this.AreaSelected = new Selection.AreaRecording();
```

**`extension.js`** — `doRecResult()`'s failure branch now calls `this.recorder.clearAreaRecording()`, so a frame drawn by any path is torn down whenever a start reports failure. `clearAreaRecording()` is idempotent, matching the existing `_disable()` and D-Bus name-owner fail-safes.

## Testing

- The failure path itself was captured in the GNOME Shell journal on GNOME Shell 42.9 (excerpt above), showing the frame being drawn and never cleared.
- Manually verified after the change: the recording-area frame is torn down rather than left behind, and the hotkey ends the recording instead of opening a new area selection.
- `npm run lint` passes clean.

## Note for reviewers

This branch is `master` and also carries the two commits already proposed in #394 (`Fail-safe cleanup of the recording-area frame`) and #395 (`Ignore the record hotkey while a start is already pending`). The change above builds directly on `clearAreaRecording()` from #394. If this is merged, #394 and #395 can be closed as superseded — or I'm happy to rebase this down to just the new commit if you'd rather take the three separately.
